### PR TITLE
SRI front source code volume

### DIFF
--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -76,7 +76,8 @@ services:
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
     volumes:
-      - ../bundle:/app/bundle
+      - ../sources/sri-front:/source
+      - ../bundle:/bundle
     stdin_open: false
     tty: true
 

--- a/postgres/init/init-noclook-db.sh
+++ b/postgres/init/init-noclook-db.sh
@@ -6,5 +6,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     ALTER USER "ni" WITH PASSWORD 'docker';
     CREATE DATABASE norduni;
     GRANT ALL PRIVILEGES ON DATABASE norduni TO ni;
+    ALTER USER ni CREATEDB;
 EOSQL
-


### PR DESCRIPTION
* Add another volume for sri-front container, so the bundle is made from the code from this volume, instead of the code copied on docker image building.
* Also small bugfix, the ni postgresql user need CREATEDB permissions in order to create the test_database for running django tests.