### PR TITLE
Change source code volume to /app

### DIFF
--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -71,7 +71,6 @@ services:
   sri-front:
     build:
       context: ../sources/sri-front
-    entrypoint: ["/app/bundle-pj.sh"]
     environment:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -71,6 +71,7 @@ services:
   sri-front:
     build:
       context: ../sources/sri-front
+    entrypoint: ["/app/bundle-pj.sh"]
     environment:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -78,6 +78,7 @@ services:
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
       - LOGIN_URL=/login/?next=/
+      - SCHEMA_VERSION=common
     volumes:
       - ../sources/sri-front:/app
       - ../bundle:/bundle

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -76,7 +76,7 @@ services:
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
     volumes:
-      - ../sources/sri-front:/source
+      - ../sources/sri-front:/app
       - ../bundle:/bundle
     stdin_open: false
     tty: true

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -62,7 +62,7 @@ services:
       - SRI_FRONTEND_URL=sri.localenv.loc
       - SCRIPT_NAME=/api
       - STATIC_URL=/api/static/
-      - INSPECT_SCHEMA=False
+      - INSPECT_SCHEMA=True
     volumes:
       - ../sources/norduni/src:/app
     command: ["dev"]
@@ -83,6 +83,11 @@ services:
       - ../bundle:/bundle
     stdin_open: false
     tty: true
+    expose:
+      - 3000
+    networks:
+      dev:
+        ipv4_address: 172.16.21.7
 
   sri-nginx:
     image: docker.sunet.se/eduid/nginx:stable
@@ -92,6 +97,7 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 3030:3030
     networks:
       dev:
         ipv4_address: 172.16.21.6

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   postgres:
-    image: postgres:latest
+    image: postgres:12
     expose:
       - 5432
     networks:

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -62,6 +62,7 @@ services:
       - SRI_FRONTEND_URL=sri.localenv.loc
       - SCRIPT_NAME=/api
       - STATIC_URL=/api/static/
+      - INSPECT_SCHEMA=False
     volumes:
       - ../sources/norduni/src:/app
     command: ["dev"]
@@ -76,6 +77,7 @@ services:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
+      - LOGIN_URL=/login/?next=/
     volumes:
       - ../sources/sri-front:/app
       - ../bundle:/bundle

--- a/norduni/nginxconf/dev-nginx.conf
+++ b/norduni/nginxconf/dev-nginx.conf
@@ -33,3 +33,17 @@ server {
         proxy_redirect off;
     }
 }
+
+server {
+    listen 3030;
+    client_max_body_size 10M;
+    # server_name  sri.localenv.loc;
+    location / {
+        proxy_pass http://sri-front:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+     }
+}


### PR DESCRIPTION
The sri-front image has changed the way it is deployed so it will work on both types of environments; development and production.

* Production: /app folder is the workdir and the source code is present on the image as the code is copied on image build time.
* Development (this case): The /app folder is mounted as a volume so every time we restart the norduni_sri-front_1 container it rebundles the code from the volume, so it is updated on container runtime.