### PR TITLE
Inspect login vars

### DIFF
--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -71,7 +71,6 @@ services:
   sri-front:
     build:
       context: ../sources/sri-front
-    entrypoint: ["/app/bundle-pj.sh"]
     environment:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -71,6 +71,7 @@ services:
   sri-front:
     build:
       context: ../sources/sri-front
+    entrypoint: ["/app/bundle-pj.sh"]
     environment:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -76,7 +76,7 @@ services:
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
     volumes:
-      - ../sources/sri-front:/source
+      - ../sources/sri-front:/app
       - ../bundle:/bundle
     stdin_open: false
     tty: true

--- a/norduni/compose.yml
+++ b/norduni/compose.yml
@@ -62,6 +62,7 @@ services:
       - SRI_FRONTEND_URL=sri.localenv.loc
       - SCRIPT_NAME=/api
       - STATIC_URL=/api/static/
+      - INSPECT_SCHEMA=False
     volumes:
       - ../sources/norduni/src:/app
     command: ["dev"]
@@ -76,6 +77,7 @@ services:
       - NODE_ENV=development
       - REACT_APP_API_HOST=sri.localenv.loc/api
       - REACT_APP_COOKIE_DOMAIN=sri.localenv.loc
+      - LOGIN_URL=/login/?next=/
     volumes:
       - ../sources/sri-front:/app
       - ../bundle:/bundle


### PR DESCRIPTION
Added two new environmend vars:

- INSPECT_SCHEMA for the ni container. This var is meant to help the retrieval of the graphql schema for the frontend development and to match the backend schema with the frontend queries in the future.
- LOGIN_URL for the sri-front. This var parametrizes the url redirection where the authentication system specified by the client is.